### PR TITLE
feat: Add markmap CLI installation to sistemo install command

### DIFF
--- a/autish/commands/sistemo.py
+++ b/autish/commands/sistemo.py
@@ -19,6 +19,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from autish.services import markmap
 from autish.services.bash_alias import BashAliasDB
 from autish.utils import echo_padded
 
@@ -695,6 +696,17 @@ def install(
                 f"[!] Ne povis instali man-paĝojn: {e}",
                 err=True,
             )
+
+        # Install markmap CLI for offline support
+        if markmap.has_markmap_cli():
+            typer.echo("[i] Markmap-cli jam instalita")
+        else:
+            typer.echo("[i] Instalanta markmap-cli por HTML-grafik-subteno...")
+            success, message = markmap.install_markmap_cli()
+            if success:
+                typer.echo("[✓] Markmap-cli instalita")
+            else:
+                typer.echo(f"[!] Markmap instalado: {message}", err=True)
     except PermissionError as e:
         scope_label = "sisteme" if sistema else "uzanto-ĉambro"
         typer.echo(

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -85,7 +85,27 @@ Context resolution order (highest priority first):
 
 ---
 
+## Testing Best Practices
+
+**Test Isolation:**
+- Use `@pytest.fixture(autouse=True)` in `conftest.py` to globally mock disruptive operations (webbrowser, file opening).
+- All tests automatically prevent browser windows and external file opens, ensuring non-disruptive test runs.
+- Individual tests can override global mocks using `monkeypatch` or `patch()` decorators for specific behavior.
+
+**Browser/File Opening in Tests:**
+- `webbrowser.open()` is mocked globally via `conftest.py` fixture to prevent actual browser windows during test runs.
+- This prevents disruption to developer workflows while tests run in the background.
+- Tests that need specific behavior can use `monkeypatch.setattr("webbrowser.open", custom_mock)`.
+
+**Database Testing:**
+- Use `monkeypatch` with `tmp_path` to redirect database file paths to isolated temporary directories.
+- Each test runs with its own isolated database instance; no shared state between tests.
+- Fixture setup should occur before module imports when database paths are used during module initialization.
+
+---
+
 ## Help Text Standards
+
 
 **Options with restricted values MUST document all valid values.**
 Example: `--stato` option must document: "Valid values: malfermita (open), farita (done), prokrastita (deferred), nuligita (cancelled)"


### PR DESCRIPTION
- Install markmap-cli locally for offline HTML visualization support
- Check if already installed and skip if present
- Add testing best practices to copilot-instructions for pytest isolation
- Document webbrowser mocking strategy in conftest.py fixture